### PR TITLE
Remove sonatype parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,61 @@
 # Digipost Open Source Project &ndash; Super-POM
 
 Common configuration for
-[Digipost open source projects](https://github.com/digipost).
+[Digipost open source projects](https://github.com/digipost). It enables deployment to
+[Sonatype's staging and snapshot repository](https://oss.sonatype.org), and provides
+some configuration of commonly used plugins.
 
+
+## Usage
+
+Add the following parent to your POM file:
+
+```xml
+<parent>
+    <groupId>no.digipost</groupId>
+    <artifactId>digipost-open-super-pom</artifactId>
+    <version>2</version>
+</parent>
+```
+
+
+## Build source and javadoc artifacts
+
+Using this POM as parent will ensure that proper artifacts are built containing source files and
+javadoc during release, which is required to be allowed to publish to the Maven Central Repository.
+This is not enabled for snapshot builds by default, but can be enabled by using the profile
+`build-sources-and-javadoc`. If you want this to be enabled for all your builds, you can create
+the file `.mvn/maven.config` in your project with the following content:
+
+```
+-P build-sources-and-javadoc
+```
+
+This mechanism [requires at least Maven 3.3.1](https://maven.apache.org/docs/3.3.1/release-notes.html), and
+you probably want to add the following to your `<build>`-&gt;`<plugins>` section of your POM to ensure this:
+
+```xml
+<plugin>
+    <artifactId>maven-enforcer-plugin</artifactId>
+    <executions>
+        <execution>
+            <id>enforce-maven</id>
+            <goals>
+                <goal>enforce</goal>
+            </goals>
+            <configuration>
+                <rules>
+                    <requireMavenVersion>
+                        <!-- Maven 3.3.1 is needed for .mvn/maven.config to work
+                             https://maven.apache.org/docs/3.3.1/release-notes.html -->
+                        <version>3.3.1</version>
+                    </requireMavenVersion>
+                </rules>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+```
 
 
 ## License

--- a/pom.xml
+++ b/pom.xml
@@ -27,14 +27,14 @@
             <extension>
                 <groupId>org.apache.maven.wagon</groupId>
                 <artifactId>wagon-webdav-jackrabbit</artifactId>
-                <version>2.9</version>
+                <version>3.2.0</version>
             </extension>
         </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.2</version>
+                    <version>2.5.3</version>
                     <configuration>
                         <scmCommentPrefix>Release:</scmCommentPrefix>
                         <tagNameFormat>@{project.version}</tagNameFormat>
@@ -44,7 +44,7 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.1</version>
+                    <version>2.7</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
                     <version>3.0.1</version>
                     <configuration>
                         <doclint>all,-missing</doclint>
+                        <quiet>true</quiet>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,9 @@
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>3.0.1</version>
+                    <configuration>
+                        <includePom>true</includePom>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.digipost</groupId>
     <artifactId>digipost-open-super-pom</artifactId>
-    <version>2</version>
+    <version>3-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Digipost Open Source Project</name>
@@ -186,7 +186,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-open-super-pom</url>
-        <tag>2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.digipost</groupId>
     <artifactId>digipost-open-super-pom</artifactId>
-    <version>2-SNAPSHOT</version>
+    <version>remove-sonatype-parent-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Digipost Open Source Project</name>

--- a/pom.xml
+++ b/pom.xml
@@ -17,15 +17,6 @@
         </license>
     </licenses>
 
-    <developers>
-        <developer>
-            <name>Rune Flobakk</name>
-            <url>https://github.com/digipost</url>
-            <organization>Digipost</organization>
-            <organizationUrl>https://digipost.no</organizationUrl>
-        </developer>
-    </developers>
-
     <build>
         <pluginManagement>
             <plugins>
@@ -209,42 +200,19 @@
         </snapshotRepository>
     </distributionManagement>
 
-    <repositories>
-        <repository>
-            <id>sonatype-nexus-public</id>
-            <url>https://oss.sonatype.org/content/groups/public</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>sonatype-nexus-releases</id>
-            <url>https://oss.sonatype.org/content/repositories/releases</url>
-        </repository>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </repository>
-    </repositories>
-
-    <pluginRepositories>
-        <pluginRepository>
-            <id>sonatype-nexus-public</id>
-            <url>https://oss.sonatype.org/content/groups/public</url>
-        </pluginRepository>
-        <pluginRepository>
-            <id>sonatype-nexus-releases</id>
-            <url>https://oss.sonatype.org/content/repositories/releases</url>
-        </pluginRepository>
-    </pluginRepositories>
-
     <organization>
         <name>Digipost</name>
         <url>https://www.digipost.no</url>
     </organization>
+
+    <developers>
+        <developer>
+            <name>Rune Flobakk</name>
+            <url>https://github.com/digipost</url>
+            <organization>Digipost</organization>
+            <organizationUrl>https://digipost.no</organizationUrl>
+        </developer>
+    </developers>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,10 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
                     <version>3.0.0-M2</version>
                     <configuration>
@@ -69,6 +73,14 @@
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>1.6</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M1</version>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>build-sources-and-javadoc,sign-artifacts,git-push-reminder</releaseProfiles>
+                        <localCheckout>true</localCheckout>
+                        <pushChanges>false</pushChanges>
                         <scmCommentPrefix>Release:</scmCommentPrefix>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
                     <configuration>
                         <mavenExecutorId>forked-path</mavenExecutorId>
                         <useReleaseProfile>false</useReleaseProfile>
-                        <arguments>${arguments} -Psonatype-oss-release</arguments>
+                        <releaseProfiles>build-sources-and-javadoc,sign-artifacts,git-push-reminder</releaseProfiles>
                         <scmCommentPrefix>Release:</scmCommentPrefix>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -101,7 +101,7 @@
 
     <profiles>
         <profile>
-            <id>sonatype-oss-release</id>
+            <id>build-sources-and-javadoc</id>
             <build>
                 <plugins>
                     <plugin>
@@ -126,6 +126,13 @@
                             </execution>
                         </executions>
                     </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>sign-artifacts</id>
+            <build>
+                <plugins>
                     <plugin>
                         <artifactId>maven-gpg-plugin</artifactId>
                         <executions>
@@ -135,6 +142,36 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>git-push-reminder</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>1.8</version>
+                        <executions>
+                            <execution>
+                                <inherited>true</inherited>
+                                <id>git-push-reminder</id>
+                                <phase>deploy</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <echo>*************************************************************************************************************</echo>
+                                        <echo> Remember to push to remote Git repository after release!</echo>
+                                        <echo/>
+                                        <echo> git push --follow-tags</echo>
+                                        <echo>*************************************************************************************************************</echo>
+                                    </target>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -201,7 +238,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <arguments />
     </properties>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,18 +17,27 @@
         </license>
     </licenses>
 
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>9</version>
-    </parent>
     <build>
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0-M2</version>
+                    <configuration>
+                        <rules>
+                            <requireMavenVersion>
+                                <version>3.0.5</version>
+                            </requireMavenVersion>
+                        </rules>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>2.5.3</version>
                     <configuration>
+                        <mavenExecutorId>forked-path</mavenExecutorId>
+                        <useReleaseProfile>false</useReleaseProfile>
+                        <arguments>${arguments} -Psonatype-oss-release</arguments>
                         <scmCommentPrefix>Release:</scmCommentPrefix>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
@@ -38,25 +47,71 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>2.7</version>
+                    <configuration>
+                        <generateBackupPoms>false</generateBackupPoms>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <configuration>
+                        <doclint>all,-missing</doclint>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>1.6</version>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-maven</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>
         <profile>
-            <id>release-sign-artifacts</id>
-            <activation>
-                <property>
-                    <name>performRelease</name>
-                    <value>true</value>
-                </property>
-            </activation>
+            <id>sonatype-oss-release</id>
             <build>
                 <plugins>
                     <plugin>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.6</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -130,9 +185,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <arguments />
     </properties>
 
-    <prerequisites>
-        <maven>2.2.1</maven>
-    </prerequisites>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -23,13 +23,6 @@
         <version>9</version>
     </parent>
     <build>
-        <extensions>
-            <extension>
-                <groupId>org.apache.maven.wagon</groupId>
-                <artifactId>wagon-webdav-jackrabbit</artifactId>
-                <version>3.2.0</version>
-            </extension>
-        </extensions>
         <pluginManagement>
             <plugins>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,15 @@
         </license>
     </licenses>
 
+    <developers>
+        <developer>
+            <name>Rune Flobakk</name>
+            <url>https://github.com/digipost</url>
+            <organization>Digipost</organization>
+            <organizationUrl>https://digipost.no</organizationUrl>
+        </developer>
+    </developers>
+
     <build>
         <pluginManagement>
             <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.digipost</groupId>
     <artifactId>digipost-open-super-pom</artifactId>
-    <version>remove-sonatype-parent-SNAPSHOT</version>
+    <version>2</version>
     <packaging>pom</packaging>
 
     <name>Digipost Open Source Project</name>
@@ -169,7 +169,7 @@
                                     <target>
                                         <echo>*************************************************************************************************************</echo>
                                         <echo> Remember to push to remote Git repository after release!</echo>
-                                        <echo/>
+                                        <echo />
                                         <echo> git push --follow-tags</echo>
                                         <echo>*************************************************************************************************************</echo>
                                     </target>
@@ -186,7 +186,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-open-super-pom</url>
-        <tag>HEAD</tag>
+        <tag>2</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
Remove the use of the old sonatype parent POM for open source projects. We specify the stuff ourselves instead, and in a better way.

