### PR TITLE
Skip CI build (Travis) for release commits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.digipost</groupId>
     <artifactId>digipost-open-super-pom</artifactId>
-    <version>3-SNAPSHOT</version>
+    <version>3</version>
     <packaging>pom</packaging>
 
     <name>Digipost Open Source Project</name>
@@ -186,7 +186,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-open-super-pom</url>
-        <tag>HEAD</tag>
+        <tag>3</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>no.digipost</groupId>
     <artifactId>digipost-open-super-pom</artifactId>
-    <version>3</version>
+    <version>4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Digipost Open Source Project</name>
@@ -186,7 +186,7 @@
         <connection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/digipost-open-super-pom.git</developerConnection>
         <url>scm:git:git@github.com:digipost/digipost-open-super-pom</url>
-        <tag>3</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
                         <releaseProfiles>build-sources-and-javadoc,sign-artifacts,git-push-reminder</releaseProfiles>
                         <localCheckout>true</localCheckout>
                         <pushChanges>false</pushChanges>
-                        <scmCommentPrefix>Release:</scmCommentPrefix>
+                        <scmCommentPrefix>[skip ci] Release: </scmCommentPrefix>
                         <tagNameFormat>@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -59,14 +59,14 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <includePom>true</includePom>
                     </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.0.1</version>
+                    <version>3.1.0</version>
                     <configuration>
                         <doclint>all,-missing</doclint>
                         <quiet>true</quiet>


### PR DESCRIPTION
These builds (especially the one which deploys the release version) are run locally, and does not need to be run by Travis. In addition, we try to employ several more or less, mostly less, functioning hacks to avoid running the deploy phase for release builds, as it has already been run when Travis picks up the commit.