### PR TITLE
Adding a defaultGoal to japicmp profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -192,12 +192,33 @@
         </profile>
         <profile>
             <id>japicmp</id>
-            <properties>
-                <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
-            </properties>
             <build>
+                <defaultGoal>enforcer:enforce@require-project.previousVersion japicmp:cmp</defaultGoal>
                 <pluginManagement>
                     <plugins>
+                        <plugin>
+                            <artifactId>maven-enforcer-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>require-project.previousVersion</id>
+                                    <goals>
+                                        <goal>enforce</goal>
+                                    </goals>
+                                    <configuration>
+                                        <rules combine.self="override">
+                                            <requireProperty>
+                                                <property>project.previousVersion</property>
+                                                <message>
+                                                    Missing project.previousVersion property!
+                                                    You must specify the version you want to compare with. Add
+                                                    -Dproject.previousVersion=X.Y to set the version to compare against you current API.
+                                                </message>
+                                            </requireProperty>
+                                        </rules>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                        </plugin>
                         <plugin>
                             <groupId>com.github.siom79.japicmp</groupId>
                             <artifactId>japicmp-maven-plugin</artifactId>


### PR DESCRIPTION
Enables generating the japicmp report by just enabling the profile:
```sh
mvn -Pjapicmp -Dproject.previousVersion=X.Y
```

Also using maven-enforcer-plugin's [requireProperty rule](https://maven.apache.org/enforcer/enforcer-rules/requireProperty.html) to give a more readable message if omitting specifying the previous version to compare against. If only running `mvn -Pjapicmp`, you will get the following error:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.2.1:enforce (require-project.previousVersion) on project <your project>:
[ERROR] Rule 0: org.apache.maven.enforcer.rules.property.RequireProperty failed with message:
[ERROR] Missing project.previousVersion property!
[ERROR]        You must specify the version you want to compare with. Add
[ERROR]        -Dproject.previousVersion=X.Y to set the version to compare against you current API.
```