### PR TITLE
Upgrade nexus-staging-mavin-plugin to central-publishing-maven-plugin

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
 
     name: Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-java@v3
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-java@v4.7.1
         with:
           distribution: temurin
           java-version: ${{ matrix.java }}
@@ -27,12 +27,37 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-      - name: Set release version
-        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF:11}"-SNAPSHOT")" >> $GITHUB_ENV
-      - name: Build and deploy to Sonatype snapshot
-        uses: digipost/action-maven-publish@1.3.2
+      - uses: actions/checkout@v4.2.2
+      - name: Set up Java
+        uses: actions/setup-java@v4.7.1
         with:
-          sonatype_secrets: ${{ secrets.sonatype_secrets }}
-          release_version: ${{ env.RELEASE_VERSION }}
-          perform_release: false
+          distribution: temurin
+          java-version: '17'
+          cache: "maven"
+          gpg-private-key: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PRIVATE}}
+          # Maven settings (generated settings.xml)
+          server-id: central
+          server-username: MAVEN_CENTRAL_TOKEN_USERNAME
+          server-password: MAVEN_CENTRAL_TOKEN_PASSWORD
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Activate Artifact Signing and Version Suffix
+        run: |
+          profiles="build-sources-and-javadoc,deploy-to-maven-central"
+          if [[ "${GITHUB_REF_TYPE}" == "tag" ]]; then
+            profiles="$profiles,sign-artifacts"
+            version_suffix=""
+          else
+            version_suffix="-SNAPSHOT"         
+          fi
+          echo "MAVEN_PROFILES=$profiles" >> $GITHUB_ENV
+          version="${GITHUB_REF_NAME}${version_suffix}"
+          echo "VERSION=$version" >> $GITHUB_ENV
+      - name: Set Maven version
+        run: mvn --batch-mode --no-transfer-progress versions:set -DnewVersion=${VERSION}
+      - name: Build and deploy to Maven Central
+        run: |
+          mvn --batch-mode --no-transfer-progress --activate-profiles ${MAVEN_PROFILES} deploy
+        env:
+          MAVEN_CENTRAL_TOKEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_TOKEN_USERNAME }}
+          MAVEN_CENTRAL_TOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_TOKEN_PASSWORD }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_CENTRAL_SIGNING_KEY_PASSPHRASE }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .settings/
 target/
 .idea/
+.vscode/settings.json
+.flattened-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -22,11 +22,11 @@
             <plugins>
                 <plugin>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.6.0</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>
@@ -37,32 +37,37 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.8.1</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.8.0</version>
                     <extensions>true</extensions>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.15.0</version>
+                    <version>2.18.0</version>
                     <configuration>
                         <generateBackupPoms>false</generateBackupPoms>
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.7.2</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.3.1</version>
                     <configuration>
                         <includePom>true</includePom>
                     </configuration>
                 </plugin>
                 <plugin>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.5.0</version>
+                    <version>3.11.2</version>
                     <configuration>
                         <doclint>all,-missing</doclint>
                         <quiet>true</quiet>
@@ -70,15 +75,15 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
+                    <version>3.2.8</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.4</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.1.4</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -121,16 +126,40 @@
             </build>
         </profile>
         <profile>
-            <id>release</id>
+            <id>deploy-to-maven-central</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>flatten-maven-plugin</artifactId>
+                        <version>1.7.2</version>
                         <configuration>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <serverId>sonatype-oss-nexus-staging</serverId>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <flattenMode>ossrh</flattenMode>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>flatten</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>flatten</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>flatten.clean</id>
+                                <goals>
+                                    <goal>clean</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+<!--                             <autoPublish>true</autoPublish> -->
                         </configuration>
                     </plugin>
                 </plugins>
@@ -335,17 +364,6 @@
         <url>scm:git:git@github.com:digipost/digipost-open-super-pom</url>
         <tag>HEAD</tag>
     </scm>
-
-    <distributionManagement>
-        <repository>
-            <id>sonatype-oss-nexus-staging</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-        <snapshotRepository>
-            <id>sonatype-oss-nexus-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-    </distributionManagement>
 
     <organization>
         <name>Digipost</name>


### PR DESCRIPTION
* Upgrade most plugins to latest versions
* Remove distributionManagement as the new plugin have the URLs embedded
* Add flatten-plugin to create valid, consumable POMs on Maven Central


